### PR TITLE
[codex] Add asset management

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@
 - Supabase 项目中需要关闭邮箱确认，否则注册后不会直接获得可用 session。
 - 如果注册测试返回 `email rate limit exceeded`，说明 Supabase 仍在尝试发确认邮件或已触发邮件限流，需要关闭 Email confirmation 或等待限流窗口。
 
+
+## 资产管理数据
+
+- 前端已接入 `public.asset_accounts`。登录且 Supabase 配置存在时，资产账户会按当前用户 `user_id` 从数据库读取和保存。
+- 资产管理需要登录；未登录进入 `/assets` 会先打开登录弹窗，不再展示本地 mock 数据。
+- 资产账户表和 RLS SQL 在 `supabase/migrations/202607030001_create_asset_accounts.sql`。
+- profiles 安全补丁在 `supabase/migrations/202607030002_harden_profiles_security.sql`。
+- 当前远端验证结果：`public.asset_accounts` 已应用到 Supabase；匿名访问受 RLS 限制，登录后可按当前用户读写。
+
 ## 视觉实现说明
 
 - 不增加右侧摘要/统计卡片；首页只负责进入功能。

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite --host 127.0.0.1",
     "build": "tsc && vite build",
-    "preview": "vite preview --host 127.0.0.1"
+    "preview": "vite preview --host 127.0.0.1",
+    "dev:tunnel": "cloudflared tunnel --config /home/jianwu/.cloudflared/life-tools-dev.yml run"
   },
   "dependencies": {
     "@mantine/core": "^8.3.9",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import {
   IconUsers,
   IconWallet,
 } from "@tabler/icons-react";
+import { useNavigate } from "@tanstack/react-router";
 import { type ComponentType, useState } from "react";
 import { AccountMenu } from "./AccountMenu";
 import { AuthModal } from "./AuthModal";
@@ -20,6 +21,7 @@ type ToolItem = {
   accent: ToolAccent;
   Icon: ComponentType<{ size?: number; stroke?: number }>;
   requiresAuth?: boolean;
+  path?: "/assets";
 };
 
 const tools: ToolItem[] = [
@@ -28,6 +30,7 @@ const tools: ToolItem[] = [
     description: "记录账户、存款和支出",
     accent: "sage",
     Icon: IconWallet,
+    path: "/assets",
   },
   {
     title: "订阅管理",
@@ -54,10 +57,16 @@ export function App() {
   const [authOpened, authModal] = useDisclosure(false);
   const [activeTool, setActiveTool] = useState<ToolItem | null>(null);
   const { isAuthenticated } = useAuth();
+  const navigate = useNavigate();
 
   const handleToolClick = (tool: ToolItem) => {
     if (tool.requiresAuth && !isAuthenticated) {
       authModal.open();
+      return;
+    }
+
+    if (tool.path) {
+      void navigate({ to: tool.path });
       return;
     }
 

--- a/src/features/assets/AssetManagementPage.tsx
+++ b/src/features/assets/AssetManagementPage.tsx
@@ -1,0 +1,657 @@
+import {
+  ActionIcon,
+  Badge,
+  Box,
+  Button,
+  Container,
+  Drawer,
+  Group,
+  NumberInput,
+  Paper,
+  ScrollArea,
+  SimpleGrid,
+  Stack,
+  Switch,
+  Text,
+  TextInput,
+  Textarea,
+  Title,
+  Tooltip,
+  UnstyledButton,
+} from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import {
+  IconArrowLeft,
+  IconChevronDown,
+  IconChevronRight,
+  IconDeviceFloppy,
+  IconEdit,
+  IconEye,
+  IconEyeOff,
+  IconPlus,
+} from "@tabler/icons-react";
+import { Link } from "@tanstack/react-router";
+import { AuthModal } from "../../AuthModal";
+import { useAuth } from "../../auth";
+import { isSupabaseConfigured, supabase } from "../../supabaseClient";
+import { useEffect, useMemo, useState } from "react";
+import {
+  assetGroups,
+  assetTypes,
+  assetTypesById,
+  type AssetAccount,
+  type AssetType,
+} from "./asset-data";
+
+type AccountFormValues = {
+  name: string;
+  note: string;
+  balance: number;
+  includeInTotal: boolean;
+};
+
+type AssetAccountRow = {
+  id: string;
+  user_id: string;
+  type_id: string;
+  name: string;
+  note: string | null;
+  balance: number | string;
+  currency: string;
+  include_in_total: boolean;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+};
+
+type AccountSaveInput = AccountFormValues & {
+  typeId: string;
+};
+
+function fromDbRow(row: AssetAccountRow): AssetAccount {
+  return {
+    id: row.id,
+    typeId: row.type_id,
+    name: row.name,
+    note: row.note ?? "",
+    balance: Number(row.balance),
+    currency: row.currency,
+    includeInTotal: row.include_in_total,
+    createdAt: row.created_at,
+  };
+}
+
+function toDbPayload(input: AccountSaveInput, userId: string) {
+  return {
+    user_id: userId,
+    type_id: input.typeId,
+    name: input.name,
+    note: input.note,
+    balance: input.balance,
+    currency: "CNY",
+    include_in_total: input.includeInTotal,
+    updated_at: new Date().toISOString(),
+  };
+}
+
+const amountFormatter = new Intl.NumberFormat("zh-CN", {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function formatAmount(value: number, visible: boolean) {
+  return visible ? amountFormatter.format(value) : "••••••";
+}
+
+export function AssetManagementPage() {
+  const { currentUser, isAuthenticated, isLoading: isAuthLoading } = useAuth();
+  const shouldUseRemote = Boolean(isSupabaseConfigured && supabase && currentUser);
+  const [remoteAccounts, setRemoteAccounts] = useState<AssetAccount[]>([]);
+  const [isAccountsLoading, setIsAccountsLoading] = useState(false);
+  const [accountsError, setAccountsError] = useState<string | null>(null);
+  const accounts = remoteAccounts;
+  const [pickerOpened, picker] = useDisclosure(false);
+  const [formOpened, form] = useDisclosure(false);
+  const [authOpened, { open: openAuthModal, close: closeAuthModal }] = useDisclosure(false);
+  const [selectedTypeId, setSelectedTypeId] = useState(assetTypes[0].id);
+  const [typePickerMode, setTypePickerMode] = useState<"create" | "change">("create");
+  const [editingAccountId, setEditingAccountId] = useState<string | null>(null);
+  const [collapsedGroups, setCollapsedGroups] = useState<Record<string, boolean>>({});
+  const [amountVisible, setAmountVisible] = useState(true);
+
+  const selectedType = assetTypesById[selectedTypeId] ?? assetTypes[0];
+  const editingAccount = accounts.find((account) => account.id === editingAccountId) ?? null;
+
+  useEffect(() => {
+    if (!isAuthLoading && !isAuthenticated) {
+      openAuthModal();
+    }
+  }, [isAuthLoading, isAuthenticated, openAuthModal]);
+
+  useEffect(() => {
+    if (!shouldUseRemote || !supabase || !currentUser) {
+      setRemoteAccounts([]);
+      setAccountsError(null);
+      setIsAccountsLoading(false);
+      return;
+    }
+
+    let mounted = true;
+    setIsAccountsLoading(true);
+    setAccountsError(null);
+
+    supabase
+      .from("asset_accounts")
+      .select("id,user_id,type_id,name,note,balance,currency,include_in_total,sort_order,created_at,updated_at")
+      .eq("user_id", currentUser.id)
+      .order("sort_order", { ascending: true })
+      .order("created_at", { ascending: false })
+      .then(({ data, error }) => {
+        if (!mounted) {
+          return;
+        }
+
+        if (error) {
+          setAccountsError(error.message);
+          setRemoteAccounts([]);
+        } else {
+          setRemoteAccounts(((data ?? []) as AssetAccountRow[]).map(fromDbRow));
+        }
+
+        setIsAccountsLoading(false);
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, [currentUser, shouldUseRemote]);
+
+  const totals = useMemo(() => {
+    return accounts.reduce(
+      (acc, account) => {
+        if (!account.includeInTotal) {
+          return acc;
+        }
+
+        const type = assetTypesById[account.typeId];
+        if (type?.kind === "liability") {
+          acc.liabilities += Math.abs(account.balance);
+        } else {
+          acc.assets += account.balance;
+        }
+
+        return acc;
+      },
+      { assets: 0, liabilities: 0 },
+    );
+  }, [accounts]);
+
+  const netAssets = totals.assets - totals.liabilities;
+
+  const groupedAccounts = useMemo(() => {
+    return assetGroups
+      .map((group) => {
+        const items = accounts.filter((account) => assetTypesById[account.typeId]?.groupId === group.id);
+        const total = items.reduce((sum, account) => {
+          if (!account.includeInTotal) {
+            return sum;
+          }
+
+          return sum + Math.abs(account.balance);
+        }, 0);
+
+        return { ...group, accounts: items, total };
+      })
+      .filter((group) => group.accounts.length > 0);
+  }, [accounts]);
+
+  const openCreateFlow = () => {
+    if (!isAuthenticated) {
+      openAuthModal();
+      return;
+    }
+
+    if (!shouldUseRemote) {
+      setAccountsError("Supabase 尚未配置，暂时无法保存资产账户。");
+      return;
+    }
+
+    setTypePickerMode("create");
+    setEditingAccountId(null);
+    picker.open();
+  };
+
+  const handleTypeSelect = (typeId: string) => {
+    setSelectedTypeId(typeId);
+    if (typePickerMode === "create") {
+      setEditingAccountId(null);
+    }
+    picker.close();
+    form.open();
+  };
+
+  const handleEdit = (account: AssetAccount) => {
+    setSelectedTypeId(account.typeId);
+    setEditingAccountId(account.id);
+    form.open();
+  };
+
+  const handleSave = async (values: AccountFormValues) => {
+    const input: AccountSaveInput = {
+      ...values,
+      typeId: selectedType.id,
+    };
+
+    if (shouldUseRemote && supabase && currentUser) {
+      setAccountsError(null);
+
+      if (editingAccount) {
+        const { data, error } = await supabase
+          .from("asset_accounts")
+          .update(toDbPayload(input, currentUser.id))
+          .eq("id", editingAccount.id)
+          .eq("user_id", currentUser.id)
+          .select("id,user_id,type_id,name,note,balance,currency,include_in_total,sort_order,created_at,updated_at")
+          .single();
+
+        if (error) {
+          setAccountsError(error.message);
+          return;
+        }
+
+        setRemoteAccounts((current) => current.map((account) => (account.id === editingAccount.id ? fromDbRow(data as AssetAccountRow) : account)));
+      } else {
+        const { data, error } = await supabase
+          .from("asset_accounts")
+          .insert(toDbPayload(input, currentUser.id))
+          .select("id,user_id,type_id,name,note,balance,currency,include_in_total,sort_order,created_at,updated_at")
+          .single();
+
+        if (error) {
+          setAccountsError(error.message);
+          return;
+        }
+
+        setRemoteAccounts((current) => [fromDbRow(data as AssetAccountRow), ...current]);
+      }
+
+      form.close();
+      return;
+    }
+
+    if (!isAuthenticated) {
+      openAuthModal();
+      return;
+    }
+
+    setAccountsError("Supabase 尚未配置，暂时无法保存资产账户。");
+  };
+
+  const toggleGroup = (groupId: string) => {
+    setCollapsedGroups((current) => ({ ...current, [groupId]: !current[groupId] }));
+  };
+
+  return (
+    <Box className="asset-shell">
+      <Container size="lg" className="asset-page">
+        <Group className="asset-topbar" justify="space-between" wrap="nowrap">
+          <Group gap="sm" wrap="nowrap">
+            <ActionIcon component={Link} to="/" variant="subtle" className="asset-nav-button" aria-label="返回首页">
+              <IconArrowLeft size={22} stroke={2} />
+            </ActionIcon>
+            <Box>
+              <Text className="asset-kicker">Life Tools</Text>
+              <Title className="asset-title" order={1}>
+                资产管理
+              </Title>
+            </Box>
+          </Group>
+
+          <Group gap="xs" wrap="nowrap">
+            <Tooltip label={amountVisible ? "隐藏金额" : "显示金额"}>
+              <ActionIcon
+                variant="subtle"
+                className="asset-nav-button"
+                aria-label={amountVisible ? "隐藏金额" : "显示金额"}
+                onClick={() => setAmountVisible((visible) => !visible)}
+              >
+                {amountVisible ? <IconEye size={21} stroke={1.9} /> : <IconEyeOff size={21} stroke={1.9} />}
+              </ActionIcon>
+            </Tooltip>
+            <Button className="asset-add-button" leftSection={<IconPlus size={20} stroke={2.2} />} onClick={openCreateFlow}>
+              添加
+            </Button>
+          </Group>
+        </Group>
+
+        <section className="asset-layout" aria-label="资产管理概览">
+          <Stack gap="md" className="asset-summary-column">
+            <Paper className="asset-net-card">
+              <Text className="asset-card-label">净资产</Text>
+              <Text className="asset-net-amount">{formatAmount(netAssets, amountVisible)}</Text>
+              <SimpleGrid cols={2} spacing="md" className="asset-metric-grid">
+                <Box>
+                  <Text className="asset-card-label">总资产</Text>
+                  <Text className="asset-metric-value">{formatAmount(totals.assets, amountVisible)}</Text>
+                </Box>
+                <Box>
+                  <Text className="asset-card-label">总负债</Text>
+                  <Text className="asset-metric-value">{formatAmount(totals.liabilities, amountVisible)}</Text>
+                </Box>
+              </SimpleGrid>
+            </Paper>
+
+            <SimpleGrid cols={2} spacing="md" className="asset-flow-grid">
+              <Paper className="asset-small-card">
+                <Text className="asset-card-label">账户数</Text>
+                <Text className="asset-metric-value">{accounts.length}</Text>
+              </Paper>
+              <Paper className="asset-small-card">
+                <Text className="asset-card-label">币种</Text>
+                <Text className="asset-metric-value">CNY</Text>
+              </Paper>
+            </SimpleGrid>
+          </Stack>
+
+          <Paper className="asset-list-panel">
+            <AssetDataStatus
+              error={accountsError}
+              isAuthenticated={isAuthenticated}
+              isConfigured={isSupabaseConfigured}
+              isLoading={isAuthLoading || isAccountsLoading}
+              isRemote={shouldUseRemote}
+            />
+            {groupedAccounts.length === 0 ? (
+              <Stack className="asset-empty" align="center" justify="center">
+                <Text className="asset-empty-title">{isAuthLoading || isAccountsLoading ? "正在加载资产账户" : isAuthenticated ? "还没有资产账户" : "请先登录"}</Text>
+                <Text className="asset-empty-copy">
+                  {isAuthLoading || isAccountsLoading
+                    ? "稍等一下，正在从数据库同步。"
+                    : isAuthenticated
+                      ? "先添加一个账户，汇总页会自动计算净资产和分组余额。"
+                      : "资产账户会按登录用户同步到数据库。"}
+                </Text>
+                <Button className="asset-add-button" leftSection={<IconPlus size={18} />} onClick={openCreateFlow}>
+                  {isAuthenticated ? "添加资产" : "去登录"}
+                </Button>
+              </Stack>
+            ) : (
+              groupedAccounts.map((group) => {
+                const collapsed = collapsedGroups[group.id];
+
+                return (
+                  <section className="asset-group" key={group.id} aria-label={group.name}>
+                    <UnstyledButton className="asset-group-header" onClick={() => toggleGroup(group.id)}>
+                      <Group gap="xs" wrap="nowrap">
+                        <Text className="asset-group-title">{group.name}</Text>
+                        {collapsed ? <IconChevronRight size={19} /> : <IconChevronDown size={19} />}
+                      </Group>
+                      <Text className="asset-group-total">{formatAmount(group.total, amountVisible)}</Text>
+                    </UnstyledButton>
+
+                    {!collapsed && (
+                      <Stack gap={0}>
+                        {group.accounts.map((account) => {
+                          const type = assetTypesById[account.typeId] ?? assetTypes[0];
+                          return (
+                            <AccountRow
+                              account={account}
+                              amountVisible={amountVisible}
+                              key={account.id}
+                              type={type}
+                              onClick={() => handleEdit(account)}
+                            />
+                          );
+                        })}
+                      </Stack>
+                    )}
+                  </section>
+                );
+              })
+            )}
+          </Paper>
+        </section>
+      </Container>
+
+      <Drawer
+        opened={pickerOpened}
+        onClose={picker.close}
+        position="bottom"
+        size="82%"
+        title="选择资产类型"
+        classNames={{ content: "asset-drawer-content", header: "asset-drawer-header", title: "asset-drawer-title", body: "asset-picker-body" }}
+      >
+        <AssetTypePicker onSelect={handleTypeSelect} />
+      </Drawer>
+
+      <Drawer
+        opened={formOpened}
+        onClose={form.close}
+        position="right"
+        size="min(520px, 100vw)"
+        title={editingAccount ? "编辑资产" : `添加资产-${selectedType.name}`}
+        classNames={{ content: "asset-form-drawer", header: "asset-drawer-header", title: "asset-drawer-title", body: "asset-form-body" }}
+      >
+        <AssetAccountForm
+          account={editingAccount}
+          type={selectedType}
+          onChangeType={() => {
+            setTypePickerMode("change");
+            form.close();
+            picker.open();
+          }}
+          onSave={handleSave}
+        />
+      </Drawer>
+
+      <AuthModal opened={authOpened} onClose={closeAuthModal} />
+    </Box>
+  );
+}
+
+function AssetDataStatus({
+  error,
+  isAuthenticated,
+  isConfigured,
+  isLoading,
+  isRemote,
+}: {
+  error: string | null;
+  isAuthenticated: boolean;
+  isConfigured: boolean;
+  isLoading: boolean;
+  isRemote: boolean;
+}) {
+  if (isLoading) {
+    return <Text className="asset-data-status">正在同步数据库...</Text>;
+  }
+
+  if (error) {
+    return <Text className="asset-data-status asset-data-status-error">数据库同步失败：{error}</Text>;
+  }
+
+  if (!isAuthenticated) {
+    return <Text className="asset-data-status">请先登录，资产账户会按用户同步到数据库。</Text>;
+  }
+
+  if (!isRemote) {
+    return <Text className="asset-data-status">{isConfigured ? "正在建立数据库会话..." : "Supabase 尚未配置，暂时无法保存资产账户。"}</Text>;
+  }
+
+  return null;
+}
+
+function AccountRow({
+  account,
+  amountVisible,
+  type,
+  onClick,
+}: {
+  account: AssetAccount;
+  amountVisible: boolean;
+  type: AssetType;
+  onClick: () => void;
+}) {
+  return (
+    <UnstyledButton className="asset-account-row" onClick={onClick}>
+      <Group gap="md" wrap="nowrap" className="asset-account-main">
+        <TypeIcon type={type} />
+        <Box className="asset-account-copy">
+          <Group gap="xs" wrap="nowrap">
+            <Text className="asset-account-name">{account.name}</Text>
+            {!account.includeInTotal && <Badge className="asset-muted-badge">不计入</Badge>}
+          </Group>
+          {account.note && <Text className="asset-account-note">{account.note}</Text>}
+        </Box>
+      </Group>
+      <Group gap="xs" wrap="nowrap" className="asset-account-balance">
+        <Text className={type.kind === "liability" ? "asset-amount-negative" : "asset-amount"}>
+          {formatAmount(Math.abs(account.balance), amountVisible)}
+        </Text>
+        <IconEdit size={16} stroke={1.9} />
+      </Group>
+    </UnstyledButton>
+  );
+}
+
+function AssetTypePicker({ onSelect }: { onSelect: (typeId: string) => void }) {
+  return (
+    <ScrollArea className="asset-picker-scroll" offsetScrollbars>
+      <Stack gap="lg">
+        {assetGroups.map((group) => {
+          const groupTypes = assetTypes.filter((type) => type.groupId === group.id);
+
+          return (
+            <section className="asset-type-section" key={group.id}>
+              <Text className="asset-type-section-title">{group.name}</Text>
+              <SimpleGrid cols={{ base: 4, xs: 5, sm: 8 }} spacing="sm" verticalSpacing="md">
+                {groupTypes.map((type) => (
+                  <UnstyledButton className="asset-type-option" key={type.id} onClick={() => onSelect(type.id)}>
+                    <TypeIcon type={type} size="lg" />
+                    <Text className="asset-type-name">{type.name}</Text>
+                  </UnstyledButton>
+                ))}
+              </SimpleGrid>
+            </section>
+          );
+        })}
+      </Stack>
+    </ScrollArea>
+  );
+}
+
+function AssetAccountForm({
+  account,
+  type,
+  onChangeType,
+  onSave,
+}: {
+  account: AssetAccount | null;
+  type: AssetType;
+  onChangeType: () => void;
+  onSave: (values: AccountFormValues) => void | Promise<void>;
+}) {
+  const [name, setName] = useState(account?.name ?? "");
+  const [note, setNote] = useState(account?.note ?? "");
+  const [balance, setBalance] = useState<string | number>(account?.balance ?? 0);
+  const [includeInTotal, setIncludeInTotal] = useState(account?.includeInTotal ?? type.kind === "asset");
+
+  useEffect(() => {
+    setName(account?.name ?? "");
+    setNote(account?.note ?? "");
+    setBalance(account?.balance ?? 0);
+    setIncludeInTotal(account?.includeInTotal ?? type.kind === "asset");
+  }, [account, type.id, type.kind]);
+
+  const normalizedBalance = typeof balance === "number" ? balance : Number(balance || 0);
+  const canSave = name.trim().length > 0 && Number.isFinite(normalizedBalance);
+
+  return (
+    <Stack gap="md" className="asset-form">
+      <Paper className="asset-form-section">
+        <UnstyledButton className="asset-form-type-row" onClick={onChangeType}>
+          <Text className="asset-form-label">账户类型</Text>
+          <Group gap="xs" wrap="nowrap">
+            <TypeIcon type={type} />
+            <Text className="asset-form-type-name">{type.name}</Text>
+            <IconChevronRight size={18} stroke={1.8} />
+          </Group>
+        </UnstyledButton>
+
+        <div className="asset-form-inline-field">
+          <Text className="asset-form-label">名称</Text>
+          <TextInput
+            classNames={{ root: "asset-inline-input-wrap", input: "asset-input" }}
+            placeholder="点此输入..."
+            value={name}
+            onChange={(event) => setName(event.currentTarget.value)}
+          />
+        </div>
+      </Paper>
+
+      <Paper className="asset-form-section">
+        <div className="asset-form-inline-field">
+          <Text className="asset-form-label">账户余额</Text>
+          <NumberInput
+            classNames={{ root: "asset-inline-input-wrap", input: "asset-input" }}
+            decimalScale={2}
+            fixedDecimalScale
+            min={0}
+            value={balance}
+            onChange={setBalance}
+          />
+        </div>
+
+        <div className="asset-form-inline-field asset-form-inline-field-start">
+          <Text className="asset-form-label">备注</Text>
+          <Textarea
+            autosize
+            minRows={2}
+            classNames={{ root: "asset-inline-input-wrap", input: "asset-input" }}
+            placeholder="可不填，例如尾号、用途或平台说明"
+            value={note}
+            onChange={(event) => setNote(event.currentTarget.value)}
+          />
+        </div>
+      </Paper>
+
+      <Paper className="asset-form-section">
+        <Group className="asset-switch-row" justify="space-between" wrap="nowrap">
+          <Box>
+            <Text className="asset-switch-title">是否计入总资产</Text>
+            <Text className="asset-switch-copy">开启后，账户余额将计入汇总页</Text>
+          </Box>
+          <Switch checked={includeInTotal} onChange={(event) => setIncludeInTotal(event.currentTarget.checked)} />
+        </Group>
+      </Paper>
+
+      <Group className="asset-form-actions" grow>
+        <Button
+          className="asset-save-button"
+          disabled={!canSave}
+          leftSection={<IconDeviceFloppy size={18} />}
+          onClick={() =>
+            void onSave({
+              name: name.trim(),
+              note: note.trim(),
+              balance: normalizedBalance,
+              includeInTotal,
+            })
+          }
+        >
+          保存
+        </Button>
+      </Group>
+    </Stack>
+  );
+}
+
+function TypeIcon({ type, size = "md" }: { type: AssetType; size?: "md" | "lg" }) {
+  const iconSize = size === "lg" ? 30 : 24;
+
+  return (
+    <span className={`asset-type-icon asset-type-icon-${size}`} style={{ backgroundColor: type.color }}>
+      <type.Icon size={iconSize} stroke={1.9} />
+    </span>
+  );
+}

--- a/src/features/assets/asset-data.ts
+++ b/src/features/assets/asset-data.ts
@@ -1,0 +1,98 @@
+import {
+  IconBrandAlipay,
+  IconBrandPaypal,
+  IconBrandWechat,
+  IconBriefcase2,
+  IconBuildingBank,
+  IconBuildingCommunity,
+  IconBus,
+  IconCash,
+  IconCashBanknote,
+  IconChartDonut2,
+  IconCoins,
+  IconCreditCard,
+  IconCurrencyYuan,
+  IconDeviceMobile,
+  IconDiamond,
+  IconPigMoney,
+  IconReceiptYuan,
+  IconShieldHeart,
+  IconWallet,
+  type Icon,
+} from "@tabler/icons-react";
+
+export type AssetKind = "asset" | "liability";
+
+export type AssetGroupId = "cash" | "credit" | "stored" | "investment" | "other";
+
+export type AssetType = {
+  id: string;
+  name: string;
+  groupId: AssetGroupId;
+  color: string;
+  Icon: Icon;
+  kind: AssetKind;
+};
+
+export type AssetGroup = {
+  id: AssetGroupId;
+  name: string;
+};
+
+export type AssetAccount = {
+  id: string;
+  typeId: string;
+  name: string;
+  note: string;
+  balance: number;
+  currency: string;
+  includeInTotal: boolean;
+  createdAt: string;
+};
+
+export const assetGroups: AssetGroup[] = [
+  { id: "cash", name: "资金账户" },
+  { id: "credit", name: "信用卡账户" },
+  { id: "stored", name: "充值账户" },
+  { id: "investment", name: "投资账户" },
+  { id: "other", name: "其它账户" },
+];
+
+export const assetTypes: AssetType[] = [
+  { id: "cash", name: "现金", groupId: "cash", color: "#6f7de8", Icon: IconCash, kind: "asset" },
+  { id: "wechat", name: "微信", groupId: "cash", color: "#1fbf72", Icon: IconBrandWechat, kind: "asset" },
+  { id: "alipay", name: "支付宝", groupId: "cash", color: "#2388f2", Icon: IconBrandAlipay, kind: "asset" },
+  { id: "bank-card", name: "银行卡", groupId: "cash", color: "#4f9ddf", Icon: IconCreditCard, kind: "asset" },
+  { id: "bank", name: "银行", groupId: "cash", color: "#d82445", Icon: IconBuildingBank, kind: "asset" },
+  { id: "provident-fund", name: "公积金", groupId: "cash", color: "#7957d5", Icon: IconReceiptYuan, kind: "asset" },
+  { id: "yu-ebao", name: "余额宝", groupId: "cash", color: "#1a9be6", Icon: IconPigMoney, kind: "asset" },
+  { id: "jd-finance", name: "京东金融", groupId: "cash", color: "#f0323f", Icon: IconWallet, kind: "asset" },
+  { id: "medical", name: "医保", groupId: "cash", color: "#6a58d7", Icon: IconShieldHeart, kind: "asset" },
+  { id: "digital-cny", name: "数字人民币", groupId: "cash", color: "#da1f2d", Icon: IconCurrencyYuan, kind: "asset" },
+  { id: "paypal", name: "Paypal", groupId: "cash", color: "#2d8bc7", Icon: IconBrandPaypal, kind: "asset" },
+  { id: "other-cash", name: "其它", groupId: "cash", color: "#7c68d9", Icon: IconCoins, kind: "asset" },
+
+  { id: "credit-card", name: "信用卡", groupId: "credit", color: "#eb704c", Icon: IconCreditCard, kind: "liability" },
+  { id: "huabei", name: "花呗", groupId: "credit", color: "#3997de", Icon: IconWallet, kind: "liability" },
+  { id: "jiebei", name: "借呗", groupId: "credit", color: "#348bd7", Icon: IconCoins, kind: "liability" },
+  { id: "jd-baitiao", name: "京东白条", groupId: "credit", color: "#ef4046", Icon: IconWallet, kind: "liability" },
+  { id: "meituan", name: "美团月付", groupId: "credit", color: "#f4ba24", Icon: IconCreditCard, kind: "liability" },
+  { id: "wechat-credit", name: "微信分付", groupId: "credit", color: "#4fac59", Icon: IconBrandWechat, kind: "liability" },
+  { id: "other-credit", name: "其它信用卡", groupId: "credit", color: "#7c68d9", Icon: IconCreditCard, kind: "liability" },
+
+  { id: "phone", name: "话费", groupId: "stored", color: "#f1662f", Icon: IconDeviceMobile, kind: "asset" },
+  { id: "utilities", name: "水电", groupId: "stored", color: "#3b9d9a", Icon: IconCashBanknote, kind: "asset" },
+  { id: "meal-card", name: "饭卡", groupId: "stored", color: "#f07b2f", Icon: IconWallet, kind: "asset" },
+  { id: "deposit", name: "押金", groupId: "stored", color: "#2f78db", Icon: IconBuildingCommunity, kind: "asset" },
+  { id: "transport", name: "公交卡", groupId: "stored", color: "#5b7283", Icon: IconBus, kind: "asset" },
+
+  { id: "fund", name: "基金", groupId: "investment", color: "#d55345", Icon: IconChartDonut2, kind: "asset" },
+  { id: "stock", name: "股票", groupId: "investment", color: "#3f8c63", Icon: IconBriefcase2, kind: "asset" },
+  { id: "wealth", name: "理财", groupId: "investment", color: "#c18a2b", Icon: IconDiamond, kind: "asset" },
+  { id: "other", name: "自定义账户", groupId: "other", color: "#6b6f7a", Icon: IconWallet, kind: "asset" },
+];
+
+export const assetTypesById = assetTypes.reduce<Record<string, AssetType>>((acc, type) => {
+  acc[type.id] = type;
+  return acc;
+}, {});

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,5 +1,6 @@
 import { createRootRoute, createRoute, createRouter, Outlet } from "@tanstack/react-router";
 import { App } from "./App";
+import { AssetManagementPage } from "./features/assets/AssetManagementPage";
 
 const rootRoute = createRootRoute({
   component: Outlet,
@@ -11,7 +12,13 @@ const indexRoute = createRoute({
   component: App,
 });
 
-const routeTree = rootRoute.addChildren([indexRoute]);
+const assetsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/assets",
+  component: AssetManagementPage,
+});
+
+const routeTree = rootRoute.addChildren([indexRoute, assetsRoute]);
 
 export const router = createRouter({ routeTree });
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -654,3 +654,670 @@ a {
     font-size: 12.5px;
   }
 }
+
+
+.asset-shell {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 82% 18%, rgba(130, 151, 101, 0.16), transparent 20rem),
+    linear-gradient(132deg, rgba(255, 255, 255, 0.92), rgba(255, 250, 244, 0.82) 48%, rgba(247, 236, 222, 0.78)),
+    var(--lt-bg);
+}
+
+.asset-page {
+  padding: 34px 34px 78px;
+}
+
+.asset-topbar {
+  margin-bottom: 26px;
+}
+
+.asset-nav-button {
+  width: 44px;
+  height: 44px;
+  color: var(--lt-text);
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(91, 71, 55, 0.12);
+  box-shadow: 0 12px 26px rgba(88, 62, 38, 0.08);
+}
+
+.asset-nav-button:hover {
+  color: var(--lt-sage-dark);
+  background: rgba(255, 255, 255, 0.96);
+}
+
+.asset-kicker {
+  color: var(--lt-sage-dark);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.asset-title {
+  color: var(--lt-text);
+  font-size: clamp(28px, 3vw, 42px);
+  line-height: 1.18;
+  letter-spacing: 0;
+}
+
+.asset-add-button,
+.asset-save-button {
+  min-height: 44px;
+  padding-inline: 20px;
+  color: white;
+  background: linear-gradient(145deg, #96a977, #6f874f);
+  border: 0;
+  box-shadow: 0 16px 32px rgba(84, 107, 59, 0.2);
+}
+
+.asset-add-button:hover,
+.asset-save-button:hover {
+  background: linear-gradient(145deg, #8fa16e, #637b47);
+}
+
+.asset-layout {
+  display: grid;
+  grid-template-columns: minmax(300px, 380px) minmax(0, 1fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.asset-summary-column {
+  position: sticky;
+  top: 24px;
+}
+
+.asset-net-card,
+.asset-small-card,
+.asset-list-panel,
+.asset-form-section {
+  border: 1px solid rgba(91, 71, 55, 0.12);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(255, 252, 247, 0.9)),
+    var(--lt-surface);
+  box-shadow: var(--lt-shadow);
+}
+
+.asset-net-card {
+  padding: 30px;
+  border-radius: 28px;
+}
+
+.asset-card-label {
+  color: #7c7068;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.asset-net-amount {
+  margin-top: 8px;
+  color: #2d211d;
+  font-size: clamp(30px, 2.7vw, 42px);
+  font-weight: 850;
+  line-height: 1.08;
+  letter-spacing: 0;
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: normal;
+  white-space: nowrap;
+}
+
+.asset-metric-grid {
+  margin-top: 28px;
+}
+
+.asset-metric-value {
+  margin-top: 5px;
+  color: #33231f;
+  font-size: 22px;
+  font-weight: 850;
+  line-height: 1.2;
+  word-break: break-word;
+}
+
+.asset-small-card {
+  min-height: 110px;
+  padding: 22px;
+  border-radius: 22px;
+}
+
+.asset-list-panel {
+  min-height: 520px;
+  overflow: hidden;
+  border-radius: 28px;
+}
+
+.asset-data-status {
+  padding: 12px 22px;
+  color: #756860;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.45;
+  background: rgba(255, 252, 247, 0.62);
+  border-bottom: 1px solid rgba(91, 71, 55, 0.08);
+}
+
+.asset-data-status-error {
+  color: var(--lt-apricot-dark);
+  background: rgba(255, 244, 234, 0.76);
+}
+
+.asset-group + .asset-group {
+  border-top: 1px solid rgba(91, 71, 55, 0.1);
+}
+
+.asset-group-header {
+  width: 100%;
+  min-height: 66px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 0 22px;
+  color: var(--lt-text);
+  background: rgba(255, 252, 247, 0.42);
+}
+
+.asset-group-header:hover {
+  background: rgba(245, 238, 229, 0.72);
+}
+
+.asset-group-title {
+  color: #2d211d;
+  font-size: 20px;
+  font-weight: 850;
+  line-height: 1.25;
+}
+
+.asset-group-total {
+  color: #3a2c26;
+  font-size: 19px;
+  font-weight: 850;
+  line-height: 1.25;
+  text-align: right;
+}
+
+.asset-account-row {
+  width: 100%;
+  min-height: 76px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 18px;
+  padding: 14px 22px;
+  color: var(--lt-text);
+  border-top: 1px solid rgba(91, 71, 55, 0.08);
+  transition:
+    background 160ms ease,
+    transform 160ms ease;
+}
+
+.asset-account-row:hover {
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.asset-account-main,
+.asset-account-copy {
+  min-width: 0;
+}
+
+.asset-account-name {
+  min-width: 0;
+  overflow: hidden;
+  color: #33231f;
+  font-size: 18px;
+  font-weight: 760;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.asset-account-note {
+  margin-top: 3px;
+  color: #867970;
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+.asset-account-balance {
+  color: #877a70;
+  justify-content: flex-end;
+}
+
+.asset-amount,
+.asset-amount-negative {
+  color: #34241f;
+  font-size: 18px;
+  font-weight: 760;
+  line-height: 1.3;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.asset-amount-negative {
+  color: #b45337;
+}
+
+.asset-muted-badge {
+  height: 20px;
+  color: #766b63;
+  background: rgba(91, 71, 55, 0.1);
+  border: 0;
+}
+
+.asset-type-icon {
+  width: 42px;
+  height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  color: white;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.24),
+    0 10px 20px rgba(50, 38, 30, 0.12);
+}
+
+.asset-type-icon-lg {
+  width: 54px;
+  height: 54px;
+}
+
+.asset-empty {
+  min-height: 520px;
+  padding: 34px;
+  text-align: center;
+}
+
+.asset-empty-title {
+  color: #30221d;
+  font-size: 22px;
+  font-weight: 850;
+}
+
+.asset-empty-copy {
+  max-width: 340px;
+  color: var(--lt-muted);
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.asset-drawer-content,
+.asset-form-drawer {
+  overflow: hidden;
+  border: 1px solid rgba(91, 71, 55, 0.12);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(255, 250, 244, 0.96)),
+    var(--lt-bg);
+}
+
+.asset-form-drawer {
+  height: 100dvh;
+}
+
+.asset-drawer-header {
+  min-height: 72px;
+  padding: 22px 24px 12px;
+  background: transparent;
+  border-bottom: 1px solid rgba(91, 71, 55, 0.08);
+}
+
+.asset-drawer-title {
+  color: #261b17;
+  font-size: 24px;
+  font-weight: 850;
+}
+
+.asset-picker-body,
+.asset-form-body {
+  padding: 22px 24px 26px;
+}
+
+.asset-form-body {
+  height: calc(100dvh - 72px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+.asset-picker-scroll {
+  height: calc(82vh - 114px);
+}
+
+.asset-type-section {
+  padding: 2px 0 16px;
+}
+
+.asset-type-section-title {
+  margin-bottom: 16px;
+  color: #372822;
+  font-size: 20px;
+  font-weight: 850;
+}
+
+.asset-type-option {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 9px;
+  padding: 8px 4px;
+  border-radius: 18px;
+  color: var(--lt-text);
+}
+
+.asset-type-option:hover {
+  background: rgba(245, 238, 229, 0.72);
+}
+
+.asset-type-name {
+  width: 100%;
+  overflow: hidden;
+  color: #5f544d;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.25;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.asset-form {
+  min-height: 100%;
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
+.asset-form-section {
+  padding: 0;
+  overflow: hidden;
+  border-radius: 22px;
+}
+
+.asset-form-section .mantine-InputWrapper-root,
+.asset-form-type-row,
+.asset-switch-row,
+.asset-form-inline-field {
+  padding: 18px 18px;
+}
+
+.asset-form-section .mantine-InputWrapper-root + .mantine-InputWrapper-root,
+.asset-switch-row,
+.asset-form-inline-field {
+  border-top: 1px solid rgba(91, 71, 55, 0.09);
+}
+
+.asset-form-type-row {
+  width: 100%;
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  color: var(--lt-text);
+}
+
+.asset-form-section > .asset-switch-row:first-child {
+  border-top: 0;
+}
+
+.asset-form-inline-field {
+  display: grid;
+  grid-template-columns: 96px minmax(0, 1fr);
+  align-items: center;
+  gap: 14px;
+}
+
+.asset-form-inline-field-start {
+  align-items: start;
+}
+
+.asset-form-inline-field-start .asset-form-label {
+  padding-top: 12px;
+}
+
+.asset-form-inline-field .asset-inline-input-wrap {
+  min-width: 0;
+  padding: 0;
+  border-top: 0;
+}
+
+.asset-form-label,
+.asset-input-label,
+.asset-switch-title {
+  color: #4a3a32;
+  font-size: 16px;
+  font-weight: 760;
+}
+
+.asset-form-type-name {
+  color: var(--lt-sage-dark);
+  font-size: 17px;
+  font-weight: 850;
+}
+
+.asset-input {
+  min-height: 46px;
+  color: var(--lt-text);
+  background: rgba(255, 252, 248, 0.9);
+  border-color: rgba(91, 71, 55, 0.14);
+  font-size: 16px;
+  line-height: 1.45;
+}
+
+.asset-input:focus,
+.asset-input:focus-within {
+  border-color: rgba(130, 151, 101, 0.72);
+}
+
+.asset-switch-copy {
+  margin-top: 4px;
+  color: #867970;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.asset-form-actions {
+  position: sticky;
+  bottom: 0;
+  z-index: 2;
+  margin-top: auto;
+  padding: 12px 0 calc(12px + env(safe-area-inset-bottom));
+  background:
+    linear-gradient(180deg, rgba(255, 250, 244, 0), rgba(255, 250, 244, 0.94) 22%, rgba(255, 250, 244, 0.98));
+  backdrop-filter: blur(10px);
+}
+
+.asset-form-actions .asset-save-button {
+  width: 100%;
+}
+
+
+@media (min-width: 641px) {
+  .asset-picker-body {
+    padding: 18px 24px 24px;
+  }
+
+  .asset-type-section {
+    padding-bottom: 10px;
+  }
+
+  .asset-type-section-title {
+    margin-bottom: 10px;
+    font-size: 18px;
+  }
+
+  .asset-type-option {
+    gap: 6px;
+    padding: 6px 2px;
+    border-radius: 14px;
+  }
+
+  .asset-type-icon-lg {
+    width: 46px;
+    height: 46px;
+  }
+
+  .asset-type-name {
+    font-size: 13px;
+  }
+}
+
+@media (max-width: 900px) {
+  .asset-page {
+    padding: 26px 18px 64px;
+  }
+
+  .asset-layout {
+    grid-template-columns: 1fr;
+    gap: 18px;
+  }
+
+  .asset-summary-column {
+    position: static;
+  }
+
+  .asset-list-panel {
+    min-height: auto;
+  }
+}
+
+@media (max-width: 640px) {
+  .asset-shell {
+    background:
+      linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(255, 249, 242, 0.86) 52%, rgba(248, 237, 224, 0.78)),
+      var(--lt-bg);
+  }
+
+  .asset-page {
+    padding: 18px 14px 48px;
+  }
+
+  .asset-topbar {
+    margin-bottom: 18px;
+  }
+
+  .asset-title {
+    font-size: 28px;
+  }
+
+  .asset-add-button {
+    min-width: 44px;
+    padding-inline: 14px;
+  }
+
+  .asset-net-card {
+    padding: 24px 20px;
+    border-radius: 24px;
+  }
+
+  .asset-net-amount {
+    font-size: clamp(32px, 11vw, 46px);
+  }
+
+  .asset-flow-grid {
+    gap: 12px;
+  }
+
+  .asset-small-card {
+    min-height: 94px;
+    padding: 18px;
+    border-radius: 20px;
+  }
+
+  .asset-metric-value,
+  .asset-group-total {
+    font-size: 18px;
+  }
+
+  .asset-group-header {
+    min-height: 58px;
+    padding-inline: 18px;
+  }
+
+  .asset-group-title {
+    font-size: 18px;
+  }
+
+  .asset-account-row {
+    min-height: 72px;
+    gap: 12px;
+    padding: 12px 16px;
+  }
+
+  .asset-account-name,
+  .asset-amount,
+  .asset-amount-negative {
+    font-size: 16px;
+  }
+
+  .asset-account-balance svg {
+    display: none;
+  }
+
+  .asset-type-icon {
+    width: 38px;
+    height: 38px;
+  }
+
+  .asset-type-icon-lg {
+    width: 50px;
+    height: 50px;
+  }
+
+  .asset-drawer-content {
+    border-radius: 26px 26px 0 0;
+  }
+
+  .asset-form-drawer {
+    width: 100% !important;
+    max-width: none;
+  }
+
+  .asset-picker-body,
+  .asset-form-body {
+    padding: 18px 18px 22px;
+  }
+
+  .asset-form-body {
+    height: calc(100dvh - 72px);
+  }
+
+  .asset-form-inline-field {
+    grid-template-columns: 78px minmax(0, 1fr);
+    gap: 10px;
+  }
+
+  .asset-form-inline-field-start .asset-form-label {
+    padding-top: 12px;
+  }
+
+  .asset-type-section-title {
+    font-size: 18px;
+  }
+
+  .asset-type-name {
+    font-size: 12px;
+  }
+}
+
+@media (max-width: 390px) {
+  .asset-page {
+    padding-inline: 12px;
+  }
+
+  .asset-nav-button {
+    width: 40px;
+    height: 40px;
+  }
+
+  .asset-add-button .mantine-Button-label {
+    display: none;
+  }
+
+  .asset-account-row {
+    grid-template-columns: minmax(0, 1fr) minmax(82px, auto);
+  }
+}

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -5,7 +5,7 @@
 ## 需要配置
 
 1. 在 Supabase 项目中关闭邮箱确认：Auth -> Providers -> Email -> Confirm email 关闭。
-2. 执行迁移 SQL：`supabase/migrations/202607020001_create_profiles.sql`。
+2. 执行迁移 SQL：`supabase/migrations/202607020001_create_profiles.sql`、`supabase/migrations/202607030001_create_asset_accounts.sql` 和 `supabase/migrations/202607030002_harden_profiles_security.sql`。
 3. 本地或部署环境配置：
 
 ```bash
@@ -25,9 +25,13 @@ VITE_SUPABASE_ANON_KEY=你的 Supabase anon/publishable key
 - Project ref：`yweklyvxuqipmiymzcih`
 - Project URL：`https://yweklyvxuqipmiymzcih.supabase.co`
 - `create_profiles` migration 已应用。
+- `create_asset_accounts` migration 已应用，用于资产管理账户数据。
+- `harden_profiles_security` migration 已应用，收紧 `handle_new_user()` 执行权限并优化 profiles RLS。
 
 ## 当前验证状态
 
 - `.env.local` 已配置 Supabase URL 和 publishable key。
 - `npm run build` 已通过。
 - Auth 注册测试当前返回 `email rate limit exceeded`，需要关闭 Email confirmation 或等待限流窗口后复测。
+- 2026-07-03 验证：远端已存在 `public.asset_accounts`，匿名请求可访问 API 但受 RLS 限制返回空数据；登录后前端会按当前用户读写。
+- Security advisor 仅剩 Auth leaked password protection 未开启。Performance advisor 对新建资产索引提示 unused index，当前无数据/低使用量下属预期。

--- a/supabase/migrations/202607030001_create_asset_accounts.sql
+++ b/supabase/migrations/202607030001_create_asset_accounts.sql
@@ -1,0 +1,57 @@
+create table if not exists public.asset_accounts (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  type_id text not null,
+  name text not null,
+  note text not null default '',
+  balance numeric(14, 2) not null default 0,
+  currency text not null default 'CNY',
+  include_in_total boolean not null default true,
+  sort_order integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint asset_accounts_name_length check (char_length(trim(name)) between 1 and 80),
+  constraint asset_accounts_balance_non_negative check (balance >= 0),
+  constraint asset_accounts_currency_cny check (currency = 'CNY')
+);
+
+create index if not exists asset_accounts_user_id_idx
+on public.asset_accounts using btree (user_id);
+
+create index if not exists asset_accounts_user_sort_idx
+on public.asset_accounts using btree (user_id, sort_order, created_at desc);
+
+grant select, insert, update, delete on table public.asset_accounts to authenticated;
+grant select, insert, update, delete on table public.asset_accounts to service_role;
+
+alter table public.asset_accounts enable row level security;
+
+drop policy if exists "Users can read their own asset accounts" on public.asset_accounts;
+drop policy if exists "Users can create their own asset accounts" on public.asset_accounts;
+drop policy if exists "Users can update their own asset accounts" on public.asset_accounts;
+drop policy if exists "Users can delete their own asset accounts" on public.asset_accounts;
+
+create policy "Users can read their own asset accounts"
+on public.asset_accounts
+for select
+to authenticated
+using ((select auth.uid()) = user_id);
+
+create policy "Users can create their own asset accounts"
+on public.asset_accounts
+for insert
+to authenticated
+with check ((select auth.uid()) = user_id);
+
+create policy "Users can update their own asset accounts"
+on public.asset_accounts
+for update
+to authenticated
+using ((select auth.uid()) = user_id)
+with check ((select auth.uid()) = user_id);
+
+create policy "Users can delete their own asset accounts"
+on public.asset_accounts
+for delete
+to authenticated
+using ((select auth.uid()) = user_id);

--- a/supabase/migrations/202607030002_harden_profiles_security.sql
+++ b/supabase/migrations/202607030002_harden_profiles_security.sql
@@ -1,0 +1,19 @@
+revoke execute on function public.handle_new_user() from public;
+revoke execute on function public.handle_new_user() from anon;
+revoke execute on function public.handle_new_user() from authenticated;
+
+drop policy if exists "Users can read their own profile" on public.profiles;
+drop policy if exists "Users can update their own profile" on public.profiles;
+
+create policy "Users can read their own profile"
+on public.profiles
+for select
+to authenticated
+using ((select auth.uid()) = id);
+
+create policy "Users can update their own profile"
+on public.profiles
+for update
+to authenticated
+using ((select auth.uid()) = id)
+with check ((select auth.uid()) = id);

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -4,6 +4,6 @@ import { defineConfig } from "vite";
 export default defineConfig({
   plugins: [react()],
   server: {
-    allowedHosts: true,
+    allowedHosts: ["life-tools-dev.12161216.xyz"],
   },
 });


### PR DESCRIPTION
## Summary

- Add an authenticated asset management page at /assets with grouped account balances, net asset totals, amount visibility toggle, and account create/edit drawers.
- Persist asset accounts in Supabase through a new public.asset_accounts table with RLS policies scoped to the current user.
- Update the home asset entry, routing, Vite host config, and Supabase documentation for the new asset data flow.

## Validation

- npm run build

## Notes

This branch was created from origin/main and cherry-picked the local asset management commit onto it, with conflicts resolved against the current main file layout.