### PR TITLE
优化界面文案和资产加载体验

### DIFF
--- a/src/features/assets/AssetManagementPage.tsx
+++ b/src/features/assets/AssetManagementPage.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Box, Button, Container, Drawer, Group, Text, Title, Tooltip } from "@mantine/core";
+import { ActionIcon, Box, Button, Container, Drawer, Group, Title, Tooltip } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { IconArrowLeft, IconEye, IconEyeOff, IconPlus } from "@tabler/icons-react";
 import { Link } from "@tanstack/react-router";
@@ -108,12 +108,9 @@ export function AssetManagementPage() {
             <ActionIcon component={Link} to="/" variant="subtle" className="asset-nav-button" aria-label="返回首页">
               <IconArrowLeft size={22} stroke={2} />
             </ActionIcon>
-            <Box>
-              <Text className="asset-kicker">Life Tools</Text>
-              <Title className="asset-title" order={1}>
-                资产管理
-              </Title>
-            </Box>
+            <Title className="asset-title" order={1}>
+              资产管理
+            </Title>
           </Group>
 
           <Group gap="xs" wrap="nowrap">
@@ -127,8 +124,13 @@ export function AssetManagementPage() {
                 {amountVisible ? <IconEye size={21} stroke={1.9} /> : <IconEyeOff size={21} stroke={1.9} />}
               </ActionIcon>
             </Tooltip>
-            <Button className="asset-add-button" leftSection={<IconPlus size={20} stroke={2.2} />} onClick={openCreateFlow}>
-              添加
+            <Button
+              className="asset-add-button"
+              leftSection={<IconPlus size={20} stroke={2.2} />}
+              aria-label="添加账户"
+              onClick={openCreateFlow}
+            >
+              添加账户
             </Button>
           </Group>
         </Group>
@@ -137,6 +139,7 @@ export function AssetManagementPage() {
           <AssetSummary
             accountsCount={accounts.length}
             amountVisible={amountVisible}
+            isLoading={isAssetLoading}
             netAssets={netAssets}
             totals={totals}
           />
@@ -173,7 +176,7 @@ export function AssetManagementPage() {
         onClose={form.close}
         position="right"
         size="min(520px, 100vw)"
-        title={editingAccount ? "编辑资产" : `添加资产-${selectedType.name}`}
+        title={editingAccount ? `编辑${selectedType.name}账户` : `添加${selectedType.name}账户`}
         classNames={{ content: "asset-form-drawer", header: "asset-drawer-header", title: "asset-drawer-title", body: "asset-form-body" }}
       >
         <AssetAccountForm

--- a/src/features/assets/components/AssetAccountForm.tsx
+++ b/src/features/assets/components/AssetAccountForm.tsx
@@ -56,10 +56,10 @@ export function AssetAccountForm({
         </UnstyledButton>
 
         <div className="asset-form-inline-field">
-          <Text className="asset-form-label">名称</Text>
+          <Text className="asset-form-label">账户名称</Text>
           <TextInput
             classNames={{ root: "asset-inline-input-wrap", input: "asset-input" }}
-            placeholder="点此输入..."
+            placeholder="输入账户名称"
             value={name}
             onChange={(event) => setName(event.currentTarget.value)}
           />
@@ -68,7 +68,7 @@ export function AssetAccountForm({
 
       <Paper className="asset-form-section">
         <div className="asset-form-inline-field">
-          <Text className="asset-form-label">账户余额</Text>
+          <Text className="asset-form-label">{type.kind === "liability" ? "当前欠款" : "当前余额"}</Text>
           <NumberInput
             classNames={{ root: "asset-inline-input-wrap", input: "asset-input" }}
             decimalScale={2}
@@ -95,8 +95,8 @@ export function AssetAccountForm({
       <Paper className="asset-form-section">
         <Group className="asset-switch-row" justify="space-between" wrap="nowrap">
           <Box>
-            <Text className="asset-switch-title">是否计入总资产</Text>
-            <Text className="asset-switch-copy">开启后，账户余额将计入汇总页</Text>
+            <Text className="asset-switch-title">计入净资产统计</Text>
+            <Text className="asset-switch-copy">开启后，此账户会参与净资产汇总</Text>
           </Box>
           <Switch checked={includeInTotal} onChange={(event) => setIncludeInTotal(event.currentTarget.checked)} />
         </Group>

--- a/src/features/assets/components/AssetAccountList.tsx
+++ b/src/features/assets/components/AssetAccountList.tsx
@@ -1,10 +1,12 @@
-import { Badge, Box, Button, Group, Paper, Stack, Text, UnstyledButton } from "@mantine/core";
+import { Badge, Box, Button, Group, Paper, Skeleton, Stack, Text, UnstyledButton } from "@mantine/core";
 import { IconChevronDown, IconChevronRight, IconEdit, IconPlus } from "@tabler/icons-react";
 import { assetTypes, assetTypesById, type AssetAccount, type AssetType } from "../asset-data";
 import { formatAmount } from "../asset-format";
 import type { GroupedAssetAccounts } from "../asset-metrics";
 import { AssetDataStatus } from "./AssetDataStatus";
 import { TypeIcon } from "./TypeIcon";
+
+const assetSkeletonRows = ["first", "second", "third", "fourth"] as const;
 
 export function AssetAccountList({
   amountVisible,
@@ -33,52 +35,76 @@ export function AssetAccountList({
 }) {
   return (
     <Paper className="asset-list-panel">
-      <AssetDataStatus
-        error={error}
-        isAuthenticated={isAuthenticated}
-        isConfigured={isConfigured}
-        isLoading={isLoading}
-        isRemote={isRemote}
-      />
-      {groupedAccounts.length === 0 ? (
-        <AssetEmptyState isAuthenticated={isAuthenticated} isLoading={isLoading} onCreate={onCreate} />
+      {isLoading ? (
+        <AssetAccountListSkeleton />
       ) : (
-        groupedAccounts.map((group) => (
-          <AssetAccountGroup
-            amountVisible={amountVisible}
-            collapsed={Boolean(collapsedGroups[group.id])}
-            group={group}
-            key={group.id}
-            onAccountClick={onAccountClick}
-            onToggle={() => onToggleGroup(group.id)}
+        <>
+          <AssetDataStatus
+            error={error}
+            isAuthenticated={isAuthenticated}
+            isConfigured={isConfigured}
+            isRemote={isRemote}
           />
-        ))
+          {groupedAccounts.length === 0 ? (
+            <AssetEmptyState isAuthenticated={isAuthenticated} onCreate={onCreate} />
+          ) : (
+            groupedAccounts.map((group) => (
+              <AssetAccountGroup
+                amountVisible={amountVisible}
+                collapsed={Boolean(collapsedGroups[group.id])}
+                group={group}
+                key={group.id}
+                onAccountClick={onAccountClick}
+                onToggle={() => onToggleGroup(group.id)}
+              />
+            ))
+          )}
+        </>
       )}
     </Paper>
   );
 }
 
+function AssetAccountListSkeleton() {
+  return (
+    <Stack
+      className="asset-list-skeleton"
+      gap={0}
+      role="status"
+      aria-label="正在加载资产账户"
+      aria-busy="true"
+    >
+      {assetSkeletonRows.map((row) => (
+        <Group className="asset-account-skeleton-row" gap="md" wrap="nowrap" key={row}>
+          <Skeleton circle height={44} />
+          <Stack className="asset-account-skeleton-copy" gap={8}>
+            <Skeleton height={18} width="42%" radius="sm" />
+            <Skeleton height={13} width="68%" radius="sm" />
+          </Stack>
+          <Skeleton height={22} width={86} radius="sm" />
+        </Group>
+      ))}
+    </Stack>
+  );
+}
+
 function AssetEmptyState({
   isAuthenticated,
-  isLoading,
   onCreate,
 }: {
   isAuthenticated: boolean;
-  isLoading: boolean;
   onCreate: () => void;
 }) {
   return (
     <Stack className="asset-empty" align="center" justify="center">
-      <Text className="asset-empty-title">{isLoading ? "正在加载资产账户" : isAuthenticated ? "还没有资产账户" : "请先登录"}</Text>
+      <Text className="asset-empty-title">{isAuthenticated ? "还没有资产账户" : "请先登录"}</Text>
       <Text className="asset-empty-copy">
-        {isLoading
-          ? "稍等一下，正在从数据库同步。"
-          : isAuthenticated
-            ? "先添加一个账户，汇总页会自动计算净资产和分组余额。"
-            : "资产账户会按登录用户同步到数据库。"}
+        {isAuthenticated
+          ? "先添加一个账户，汇总页会自动计算净资产和分组余额。"
+          : "资产账户会按登录用户同步到数据库。"}
       </Text>
       <Button className="asset-add-button" leftSection={<IconPlus size={18} />} onClick={onCreate}>
-        {isAuthenticated ? "添加资产" : "去登录"}
+        {isAuthenticated ? "添加账户" : "去登录"}
       </Button>
     </Stack>
   );

--- a/src/features/assets/components/AssetDataStatus.tsx
+++ b/src/features/assets/components/AssetDataStatus.tsx
@@ -4,19 +4,13 @@ export function AssetDataStatus({
   error,
   isAuthenticated,
   isConfigured,
-  isLoading,
   isRemote,
 }: {
   error: string | null;
   isAuthenticated: boolean;
   isConfigured: boolean;
-  isLoading: boolean;
   isRemote: boolean;
 }) {
-  if (isLoading) {
-    return <Text className="asset-data-status">正在同步数据库...</Text>;
-  }
-
   if (error) {
     return <Text className="asset-data-status asset-data-status-error">数据库同步失败：{error}</Text>;
   }

--- a/src/features/assets/components/AssetSummary.tsx
+++ b/src/features/assets/components/AssetSummary.tsx
@@ -1,31 +1,45 @@
-import { Box, Paper, SimpleGrid, Stack, Text } from "@mantine/core";
+import { Box, Paper, SimpleGrid, Skeleton, Stack, Text } from "@mantine/core";
 import { formatAmount } from "../asset-format";
 import type { AssetTotals } from "../asset-metrics";
 
 export function AssetSummary({
   accountsCount,
   amountVisible,
+  isLoading,
   netAssets,
   totals,
 }: {
   accountsCount: number;
   amountVisible: boolean;
+  isLoading: boolean;
   netAssets: number;
   totals: AssetTotals;
 }) {
   return (
-    <Stack gap="md" className="asset-summary-column">
+    <Stack gap="md" className="asset-summary-column" aria-busy={isLoading}>
       <Paper className="asset-net-card">
         <Text className="asset-card-label">净资产</Text>
-        <Text className="asset-net-amount">{formatAmount(netAssets, amountVisible)}</Text>
+        {isLoading ? (
+          <Skeleton className="asset-net-skeleton" height={45} radius="md" />
+        ) : (
+          <Text className="asset-net-amount">{formatAmount(netAssets, amountVisible)}</Text>
+        )}
         <SimpleGrid cols={2} spacing="md" className="asset-metric-grid">
           <Box>
             <Text className="asset-card-label">总资产</Text>
-            <Text className="asset-metric-value">{formatAmount(totals.assets, amountVisible)}</Text>
+            {isLoading ? (
+              <Skeleton className="asset-metric-skeleton" height={27} radius="sm" />
+            ) : (
+              <Text className="asset-metric-value">{formatAmount(totals.assets, amountVisible)}</Text>
+            )}
           </Box>
           <Box>
             <Text className="asset-card-label">总负债</Text>
-            <Text className="asset-metric-value">{formatAmount(totals.liabilities, amountVisible)}</Text>
+            {isLoading ? (
+              <Skeleton className="asset-metric-skeleton" height={27} radius="sm" />
+            ) : (
+              <Text className="asset-metric-value">{formatAmount(totals.liabilities, amountVisible)}</Text>
+            )}
           </Box>
         </SimpleGrid>
       </Paper>
@@ -33,7 +47,11 @@ export function AssetSummary({
       <SimpleGrid cols={2} spacing="md" className="asset-flow-grid">
         <Paper className="asset-small-card">
           <Text className="asset-card-label">账户数</Text>
-          <Text className="asset-metric-value">{accountsCount}</Text>
+          {isLoading ? (
+            <Skeleton className="asset-count-skeleton" height={27} radius="sm" />
+          ) : (
+            <Text className="asset-metric-value">{accountsCount}</Text>
+          )}
         </Paper>
         <Paper className="asset-small-card">
           <Text className="asset-card-label">币种</Text>

--- a/src/features/assets/use-asset-accounts.ts
+++ b/src/features/assets/use-asset-accounts.ts
@@ -20,6 +20,7 @@ export function useAssetAccounts(currentUser: User | null) {
   const shouldUseRemote = Boolean(isSupabaseConfigured && supabase && currentUser);
   const [accounts, setAccounts] = useState<AssetAccount[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [loadedUserId, setLoadedUserId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -27,6 +28,7 @@ export function useAssetAccounts(currentUser: User | null) {
       setAccounts([]);
       setError(null);
       setIsLoading(false);
+      setLoadedUserId(null);
       return;
     }
 
@@ -52,6 +54,7 @@ export function useAssetAccounts(currentUser: User | null) {
           setAccounts(((data ?? []) as AssetAccountRow[]).map(fromDbRow));
         }
 
+        setLoadedUserId(currentUser.id);
         setIsLoading(false);
       });
 
@@ -111,7 +114,7 @@ export function useAssetAccounts(currentUser: User | null) {
   return {
     accounts,
     error,
-    isLoading,
+    isLoading: isLoading || Boolean(shouldUseRemote && loadedUserId !== currentUser?.id),
     saveAccount,
     setError,
     shouldUseRemote,

--- a/src/features/auth/AccountMenu.tsx
+++ b/src/features/auth/AccountMenu.tsx
@@ -1,5 +1,5 @@
 import { ActionIcon, Menu, Text, Tooltip } from "@mantine/core";
-import { IconLogout, IconSettings, IconUserCircle } from "@tabler/icons-react";
+import { IconLogout, IconUserCircle } from "@tabler/icons-react";
 import { useAuth } from "./auth-context";
 
 type AccountMenuProps = {
@@ -45,12 +45,8 @@ export function AccountMenu({ onLoginClick }: AccountMenuProps) {
         <Menu.Label>当前账号</Menu.Label>
         <div className="account-card">
           <Text className="account-name">{currentUser.username}</Text>
-          <Text className="account-email">在线同步中</Text>
         </div>
         <Menu.Divider />
-        <Menu.Item leftSection={<IconSettings size={17} />} disabled>
-          账号设置
-        </Menu.Item>
         <Menu.Item leftSection={<IconLogout size={17} />} color="apricot" onClick={logout}>
           退出登录
         </Menu.Item>

--- a/src/features/auth/AuthModal.tsx
+++ b/src/features/auth/AuthModal.tsx
@@ -6,7 +6,6 @@ import {
   PasswordInput,
   SegmentedControl,
   Stack,
-  Text,
   TextInput,
 } from "@mantine/core";
 import { IconAlertCircle, IconLock, IconUser } from "@tabler/icons-react";
@@ -62,8 +61,16 @@ export function AuthModal({ opened, onClose }: AuthModalProps) {
       return "账号服务尚未配置";
     }
 
+    if (!normalizedUsername) {
+      return "请输入用户名";
+    }
+
     if (!usernamePattern.test(normalizedUsername)) {
       return "用户名只能包含小写字母、数字、下划线，长度 3-24 位";
+    }
+
+    if (!password) {
+      return "请输入密码";
     }
 
     if (password.length < 6) {
@@ -118,27 +125,20 @@ export function AuthModal({ opened, onClose }: AuthModalProps) {
     >
       <form className="auth-form" onSubmit={handleSubmit}>
         <Stack gap="md">
-          <div>
-            <SegmentedControl
-              fullWidth
-              value={mode}
-              onChange={handleModeChange}
-              data={[
-                { value: "login", label: "登录" },
-                { value: "register", label: "注册" },
-              ]}
-              classNames={{
-                root: "auth-segmented",
-                indicator: "auth-segmented-indicator",
-                label: "auth-segmented-label",
-              }}
-            />
-            <Text className="auth-helper">
-              {mode === "login"
-                ? "使用你的用户名继续，数据会回到同一个工具台。"
-                : "创建一个轻量账号，用来保存和同步你的生活工具数据。"}
-            </Text>
-          </div>
+          <SegmentedControl
+            fullWidth
+            value={mode}
+            onChange={handleModeChange}
+            data={[
+              { value: "login", label: "登录" },
+              { value: "register", label: "注册" },
+            ]}
+            classNames={{
+              root: "auth-segmented",
+              indicator: "auth-segmented-indicator",
+              label: "auth-segmented-label",
+            }}
+          />
 
           {!isConfigured ? (
             <Alert
@@ -164,7 +164,7 @@ export function AuthModal({ opened, onClose }: AuthModalProps) {
 
           <TextInput
             label="用户名"
-            placeholder="例如 jianwu"
+            placeholder="输入用户名"
             value={username}
             onChange={(event) => setUsername(event.currentTarget.value.toLowerCase())}
             leftSection={<IconUser size={18} />}
@@ -174,7 +174,7 @@ export function AuthModal({ opened, onClose }: AuthModalProps) {
 
           <PasswordInput
             label="密码"
-            placeholder="至少 6 位"
+            placeholder="输入密码"
             value={password}
             onChange={(event) => setPassword(event.currentTarget.value)}
             leftSection={<IconLock size={18} />}
@@ -182,8 +182,7 @@ export function AuthModal({ opened, onClose }: AuthModalProps) {
             radius="lg"
           />
 
-          <Group justify="space-between" align="center" className="auth-actions">
-            <Text className="auth-note">用户名注册后暂不支持修改。</Text>
+          <Group justify="flex-end" className="auth-actions">
             <Button
               className="modal-action"
               type="submit"

--- a/src/features/home/HomePage.tsx
+++ b/src/features/home/HomePage.tsx
@@ -37,7 +37,6 @@ export function HomePage() {
 
       <Container size="xl" component="main" className="main-content">
         <section className="hero" aria-labelledby="home-title">
-          <Text className="hero-kicker">Personal Life Toolkit</Text>
           <Title id="home-title" className="hero-title">
             生活里的小事务，有个稳定入口
           </Title>

--- a/src/features/home/ToolPreviewModal.tsx
+++ b/src/features/home/ToolPreviewModal.tsx
@@ -25,7 +25,7 @@ export function ToolPreviewModal({ opened, tool, onClose }: ToolPreviewModalProp
       </Text>
       <Group justify="flex-end" mt={rem(24)}>
         <Button className="modal-action" onClick={onClose} radius="xl">
-          先看看
+          知道了
         </Button>
       </Group>
     </Modal>

--- a/src/styles.css
+++ b/src/styles.css
@@ -138,37 +138,22 @@ a {
   line-height: 1.35;
 }
 
-.account-email {
-  color: var(--lt-muted);
-  font-size: 13px;
-  line-height: 1.45;
-  word-break: break-all;
-}
-
 .main-content {
   padding: 52px 58px 88px;
 }
 
 .hero {
-  width: min(860px, 100%);
+  width: 100%;
   margin-bottom: 42px;
 }
 
-.hero-kicker {
-  margin-bottom: 14px;
-  color: var(--lt-sage-dark);
-  font-size: 13px;
-  font-weight: 800;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
 .hero-title {
-  max-width: 800px;
+  max-width: none;
   color: var(--lt-text);
-  font-size: clamp(44px, 3.6vw, 60px);
+  font-size: clamp(42px, 3.2vw, 54px);
   line-height: 1.16;
   letter-spacing: 0;
+  white-space: nowrap;
 }
 
 .hero-subtitle {
@@ -182,7 +167,7 @@ a {
 
 .tools-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 28px;
   align-items: stretch;
 }
@@ -422,13 +407,6 @@ a {
   font-weight: 800;
 }
 
-.auth-helper {
-  margin-top: 12px;
-  color: var(--lt-muted);
-  font-size: 14px;
-  line-height: 1.6;
-}
-
 .auth-alert {
   color: var(--lt-apricot-dark);
   background: rgba(255, 244, 234, 0.86);
@@ -437,12 +415,6 @@ a {
 
 .auth-actions {
   gap: 14px;
-}
-
-.auth-note {
-  color: var(--lt-muted);
-  font-size: 13px;
-  line-height: 1.5;
 }
 
 @media (max-width: 1180px) {
@@ -463,6 +435,10 @@ a {
 
   .hero {
     margin-bottom: 38px;
+  }
+
+  .tools-grid {
+    grid-template-columns: 1fr;
   }
 
   .tool-card {
@@ -536,6 +512,7 @@ a {
   .hero-title {
     font-size: clamp(36px, 9.2vw, 48px);
     line-height: 1.18;
+    white-space: normal;
   }
 
   .hero-subtitle {
@@ -695,14 +672,6 @@ a {
   background: rgba(255, 255, 255, 0.96);
 }
 
-.asset-kicker {
-  color: var(--lt-sage-dark);
-  font-size: 12px;
-  font-weight: 800;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
 .asset-title {
   color: var(--lt-text);
   font-size: clamp(28px, 3vw, 42px);
@@ -785,6 +754,17 @@ a {
   word-break: break-word;
 }
 
+.asset-net-skeleton {
+  width: min(210px, 72%);
+  margin-top: 8px;
+}
+
+.asset-metric-skeleton,
+.asset-count-skeleton {
+  width: min(110px, 72%);
+  margin-top: 5px;
+}
+
 .asset-small-card {
   min-height: 110px;
   padding: 22px;
@@ -795,6 +775,29 @@ a {
   min-height: 520px;
   overflow: hidden;
   border-radius: 28px;
+}
+
+.asset-list-skeleton {
+  padding-block: 10px;
+}
+
+.asset-account-skeleton-row {
+  min-height: 88px;
+  padding: 18px 24px;
+  border-bottom: 1px solid rgba(91, 71, 55, 0.08);
+}
+
+.asset-account-skeleton-row:last-child {
+  border-bottom: 0;
+}
+
+.asset-account-skeleton-row > .mantine-Skeleton-root:first-child {
+  flex: 0 0 auto;
+}
+
+.asset-account-skeleton-copy {
+  flex: 1;
+  min-width: 0;
 }
 
 .asset-data-status {
@@ -1254,6 +1257,16 @@ a {
     min-height: 72px;
     gap: 12px;
     padding: 12px 16px;
+  }
+
+  .asset-empty {
+    min-height: 360px;
+    padding: 28px 20px;
+  }
+
+  .asset-account-skeleton-row {
+    min-height: 72px;
+    padding: 14px 18px;
   }
 
   .asset-account-name,


### PR DESCRIPTION
## 改动内容

- 精简首页、登录注册和账户菜单中的冗余文案
- 调整首页标题与工具卡布局，改善桌面端断行和卡片空间
- 修正资产页标题区对齐，统一新增账户相关文案
- 优化资产表单字段文案，区分资产余额与负债欠款
- 为资产汇总和账户列表增加骨架加载态
- 修正已登录用户进入资产页时首帧短暂显示零值的问题

## 用户影响

页面信息更直接，桌面端布局更稳定；资产数据加载完成前会显示骨架屏，不再从 `0.00` 突变为真实数据。

## 验证

- `npm run build`
- `git diff --check`
- 暂存内容密钥扫描
