### PR TITLE
feat: improve subscription cycle picker

### DIFF
--- a/src/features/subscriptions/components/SubscriptionForm.tsx
+++ b/src/features/subscriptions/components/SubscriptionForm.tsx
@@ -1,19 +1,22 @@
 import {
   Button,
   Checkbox,
+  Drawer,
   Group,
   NumberInput,
-  SegmentedControl,
   Select,
   Stack,
   Text,
   TextInput,
+  UnstyledButton,
 } from "@mantine/core";
 import { DatePickerInput } from "@mantine/dates";
 import { useMediaQuery } from "@mantine/hooks";
 import {
   IconArchive,
   IconCalendar,
+  IconCheck,
+  IconChevronRight,
   IconDeviceFloppy,
 } from "@tabler/icons-react";
 import { useRef, useState } from "react";
@@ -45,6 +48,61 @@ const reminderOptions = [0, 1, 3, 7].map((offset) => ({
   label: offset === 0 ? "续费当天" : `提前 ${offset} 天`,
 }));
 const datePopoverProps = { withinPortal: true, shadow: "xl" as const, position: "bottom-start" as const };
+
+function MobileCyclePicker({
+  value,
+  onChange,
+}: {
+  value: CyclePreset;
+  onChange: (value: CyclePreset) => void;
+}) {
+  const [opened, setOpened] = useState(false);
+  const selected = cycleOptions.find((option) => option.value === value);
+
+  return (
+    <>
+      <div>
+        <Text className="subscription-field-label">续费周期</Text>
+        <UnstyledButton className="subscription-service-trigger" onClick={() => setOpened(true)}>
+          <Group gap="sm" wrap="nowrap">
+            <Text className="subscription-service-trigger-name">{selected?.label}</Text>
+            <IconChevronRight size={18} aria-hidden="true" />
+          </Group>
+        </UnstyledButton>
+      </div>
+      <Drawer
+        opened={opened}
+        onClose={() => setOpened(false)}
+        position="bottom"
+        size="50dvh"
+        title="选择续费周期"
+        classNames={{
+          content: "subscription-service-drawer",
+          header: "subscription-service-drawer-header",
+          title: "subscription-service-drawer-title",
+          body: "subscription-cycle-drawer-body",
+        }}
+      >
+        {cycleOptions.map((option) => (
+          <UnstyledButton
+            key={option.value}
+            className="subscription-service-row"
+            data-selected={option.value === value || undefined}
+            onClick={() => {
+              onChange(option.value as CyclePreset);
+              setOpened(false);
+            }}
+          >
+            <Group justify="space-between">
+              <Text>{option.label}</Text>
+              {option.value === value && <IconCheck size={17} aria-hidden="true" />}
+            </Group>
+          </UnstyledButton>
+        ))}
+      </Drawer>
+    </>
+  );
+}
 
 function getCyclePreset(subscription: Subscription | null): CyclePreset {
   if (!subscription) return "monthly";
@@ -286,20 +344,17 @@ export function SubscriptionForm({
           />
         </div>
 
-        <div className="subscription-cycle-field">
-          <Text className="subscription-field-label">续费周期</Text>
-          <SegmentedControl
-            fullWidth
-            data={cycleOptions}
+        {isMobile ? (
+          <MobileCyclePicker
             value={cyclePreset}
             onChange={(value) => {
-              setCyclePreset(value as CyclePreset);
+              setCyclePreset(value);
               clearError("cycle");
             }}
-            className="subscription-cycle-control subscription-cycle-desktop"
           />
+        ) : (
           <Select
-            aria-label="续费周期"
+            label="续费周期"
             data={cycleOptions}
             allowDeselect={false}
             value={cyclePreset}
@@ -307,10 +362,10 @@ export function SubscriptionForm({
               setCyclePreset((value as CyclePreset | null) ?? "monthly");
               clearError("cycle");
             }}
-            className="subscription-cycle-mobile"
+            comboboxProps={subscriptionSelectComboboxProps}
             classNames={subscriptionSelectClassNames}
           />
-        </div>
+        )}
 
         {cyclePreset === "custom" && (
           <div className="subscription-form-grid subscription-form-grid-two subscription-custom-cycle">

--- a/src/features/subscriptions/components/subscription-components.test.tsx
+++ b/src/features/subscriptions/components/subscription-components.test.tsx
@@ -57,6 +57,8 @@ describe("subscription Mantine components", () => {
     expect(markup).toContain("服务名称");
     expect(markup).toContain("每期金额");
     expect(markup).toContain("续费周期");
+    expect(markup).toContain("mantine-Select-root");
+    expect(markup).not.toContain("mantine-SegmentedControl-root");
     expect(markup).toContain("下一续费日");
     expect(markup).toContain("站内提醒时间");
     expect(markup).toContain("续费当天");

--- a/src/styles.css
+++ b/src/styles.css
@@ -963,10 +963,6 @@ a {
 .subscription-input:focus-within { border-color: #d88842; }
 
 .subscription-field-label { margin-bottom: 7px; color: #4f423a; font-size: 14px; font-weight: 600; }
-.subscription-cycle-control { min-height: 46px; padding: 3px; border: 1px solid rgba(91, 71, 55, 0.13); background: #fffdfa; }
-.subscription-cycle-control .mantine-SegmentedControl-label { padding-inline: 8px; font-size: 12px; font-weight: 750; }
-.subscription-cycle-control .mantine-SegmentedControl-indicator { border: 1px solid #d78a49; box-shadow: none; }
-.subscription-cycle-mobile { display: none; }
 .subscription-custom-cycle { margin-top: 12px; }
 
 .subscription-select-dropdown {
@@ -1004,6 +1000,7 @@ a {
 .subscription-service-drawer-header { min-height: 64px; padding: 16px 18px; border-bottom: 1px solid rgba(80, 61, 49, 0.08); }
 .subscription-service-drawer-title { color: #2d221d; font-size: 20px; font-weight: 850; }
 .subscription-service-drawer-body { height: calc(78dvh - 64px); display: flex; flex-direction: column; gap: 12px; padding: 14px 14px calc(12px + env(safe-area-inset-bottom)); overflow: hidden; }
+.subscription-cycle-drawer-body { padding: 8px 14px calc(12px + env(safe-area-inset-bottom)); }
 .subscription-service-list { min-height: 0; flex: 1; }
 .subscription-service-group + .subscription-service-group { margin-top: 12px; }
 .subscription-service-group-title { padding: 7px 8px; color: #9a806d; font-size: 11px; font-weight: 850; }
@@ -1077,8 +1074,6 @@ a {
   .subscription-form-surface { padding: 16px 15px; border-radius: 16px; }
   .subscription-form-grid-two { grid-template-columns: 1fr; }
   .subscription-form-grid-amount { grid-template-columns: minmax(0, 1.25fr) minmax(110px, 0.75fr); }
-  .subscription-cycle-desktop { display: none; }
-  .subscription-cycle-mobile { display: block; }
   .subscription-archive-row { align-items: flex-start; flex-direction: column; }
 
 }


### PR DESCRIPTION
## 改动

- Web 端续费周期改为下拉选择框
- 移动端改为底部半屏选择抽屉
- 复用现有订阅服务选择器样式，并补充组件断言

## 原因

原有 Web 分段按钮视觉拥挤，移动端普通下拉也不符合服务选择器的交互模式。

## 验证

- `npm test -- --run src/features/subscriptions/components/subscription-components.test.tsx`（9/9 通过）
- `npm run build`（通过）
